### PR TITLE
feat: add shortest CBOR floating-point encoding option

### DIFF
--- a/Sources/SwiftCbor/CborEncoder.swift
+++ b/Sources/SwiftCbor/CborEncoder.swift
@@ -21,7 +21,7 @@ open class CborEncoder {
   }
 
   func encodeAsCborValue<T: Encodable>(_ value: T) throws -> CborEncodedValue {
-    let encoder = _CborEncoder(codingPath: [])
+    let encoder = _CborEncoder(codingPath: [], options: options)
     guard let result = try encoder.wrapEncodable(value, for: CodingKey?.none) else {
       throw EncodingError.invalidValue(
         value,
@@ -35,9 +35,11 @@ open class CborEncoder {
 private class _CborEncoder: Encoder {
   public var codingPath: [CodingKey] = []
   public var userInfo: [CodingUserInfoKey: Any] = [:]
+  let options: CborEncoder.Options
 
-  init(codingPath: [CodingKey] = []) {
+  init(codingPath: [CodingKey], options: CborEncoder.Options) {
     self.codingPath = codingPath
+    self.options = options
   }
 
   var singleValue: CborEncodedValue?
@@ -422,7 +424,7 @@ extension _SpecialTreatmentEncoder {
   fileprivate func getEncoder(for additionalKey: CodingKey?) -> _CborEncoder {
     if let additionalKey {
       let newCodidngPath: [CodingKey] = codingPath + [additionalKey]
-      return _CborEncoder(codingPath: newCodidngPath)
+      return _CborEncoder(codingPath: newCodidngPath, options: encoder.options)
     }
     return encoder
   }

--- a/Sources/SwiftCbor/CborEncoder.swift
+++ b/Sources/SwiftCbor/CborEncoder.swift
@@ -268,7 +268,7 @@ extension FixedWidthInteger {
 }
 
 extension _SpecialTreatmentEncoder {
-  fileprivate func wrapFloat<F: FloatingPoint & DataNumber>(
+  fileprivate func wrapFloat<F: BinaryFloatingPoint & DataNumber>(
     _ value: F, for additionalKey: CodingKey?
   ) throws -> CborEncodedValue {
     let bits = value.bytes
@@ -511,7 +511,7 @@ private struct CborSingleValueEncodingContainer: SingleValueEncodingContainer,
   }
 
   @inline(__always)
-  private func encodeFloat<T: FloatingPoint & DataNumber>(_ value: T) throws {
+  private func encodeFloat<T: BinaryFloatingPoint & DataNumber>(_ value: T) throws {
     encoder.singleValue = try encoder.wrapFloat(value, for: nil)
   }
 }
@@ -610,7 +610,7 @@ private struct CborUnkeyedEncodingContainer: UnkeyedEncodingContainer {
     try array.append(encoder.wrapInt(value, for: nil))
   }
 
-  private func encodeFloat(_ value: some FloatingPoint & DataNumber) throws {
+  private func encodeFloat(_ value: some BinaryFloatingPoint & DataNumber) throws {
     try array.append(encoder.wrapFloat(value, for: nil))
   }
 
@@ -756,7 +756,7 @@ private struct CborKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerP
     return newEncoder
   }
 
-  private func encodeFloat(_ value: some FloatingPoint & DataNumber, for key: Key) throws {
+  private func encodeFloat(_ value: some BinaryFloatingPoint & DataNumber, for key: Key) throws {
     let value = try encoder.wrapFloat(value, for: nil)
     try map.set(value, for: encoder.wrapStringKey(key.stringValue, for: key))
   }

--- a/Sources/SwiftCbor/CborEncoder.swift
+++ b/Sources/SwiftCbor/CborEncoder.swift
@@ -271,6 +271,9 @@ extension _SpecialTreatmentEncoder {
   fileprivate func wrapFloat<F: BinaryFloatingPoint & DataNumber>(
     _ value: F, for additionalKey: CodingKey?
   ) throws -> CborEncodedValue {
+    if encoder.options.contains(.shortestFloatingPointEncoding) {
+      return shortestFloatingPointValue(value)
+    }
     let bits = value.bytes
     if bits.count == 2 {
       return .literal([0xF9] + bits)
@@ -293,6 +296,64 @@ extension _SpecialTreatmentEncoder {
         codingPath: path,
         debugDescription: "Unable to encode \(F.self).\(value) directly in MessagePack."
       ))
+  }
+
+  private func shortestFloatingPointValue(
+    _ value: some BinaryFloatingPoint & DataNumber
+  ) -> CborEncodedValue {
+    if value.isNaN {
+      return shortestNaNValue(value)
+    }
+
+    let double = Double(value)
+    let half = Float16(double)
+    if sameFloatingPointValue(Double(half), double) {
+      return .literal([0xF9] + half.bytes)
+    }
+
+    let single = Float(double)
+    if sameFloatingPointValue(Double(single), double) {
+      return .literal([0xFA] + single.bytes)
+    }
+
+    return .literal([0xFB] + double.bytes)
+  }
+
+  private func shortestNaNValue<F: BinaryFloatingPoint & DataNumber>(
+    _ value: F
+  ) -> CborEncodedValue {
+    let significand = UInt64(value.significandBitPattern)
+    let sourceWidth = F.significandBitCount
+    let isNegative = value.sign == .minus
+
+    if let narrowed = narrowedNaNSignificand(significand, from: sourceWidth, to: 10) {
+      let sign: UInt16 = isNegative ? 0x8000 : 0
+      let bits = Float16(bitPattern: sign | 0x7C00 | UInt16(narrowed)).bytes
+      return .literal([0xF9] + bits)
+    }
+
+    if let narrowed = narrowedNaNSignificand(significand, from: sourceWidth, to: 23) {
+      let sign: UInt32 = isNegative ? 0x8000_0000 : 0
+      let bits = Float(bitPattern: sign | 0x7F80_0000 | UInt32(narrowed)).bytes
+      return .literal([0xFA] + bits)
+    }
+
+    return .literal([0xFB] + value.bytes)
+  }
+
+  private func narrowedNaNSignificand(
+    _ significand: UInt64, from sourceWidth: Int, to targetWidth: Int
+  ) -> UInt64? {
+    guard sourceWidth >= targetWidth else { return nil }
+    let discardedWidth = sourceWidth - targetWidth
+    let discardedMask = discardedWidth == 0 ? 0 : (UInt64(1) << discardedWidth) - 1
+    guard significand & discardedMask == 0 else { return nil }
+    let narrowed = significand >> discardedWidth
+    return narrowed == 0 ? nil : narrowed
+  }
+
+  private func sameFloatingPointValue(_ lhs: Double, _ rhs: Double) -> Bool {
+    lhs == rhs && (lhs != 0 || lhs.sign == rhs.sign)
   }
 
   fileprivate func wrapInt(

--- a/Sources/SwiftCbor/CborEncoderOptions.swift
+++ b/Sources/SwiftCbor/CborEncoderOptions.swift
@@ -7,5 +7,6 @@ extension CborEncoder {
     }
 
     public static let lexicographicallySortedMapKeys = Options(rawValue: 1 << 0)
+    public static let shortestFloatingPointEncoding = Options(rawValue: 1 << 1)
   }
 }

--- a/Tests/SwiftCborTests/CborCodingOptionsTests.swift
+++ b/Tests/SwiftCborTests/CborCodingOptionsTests.swift
@@ -127,4 +127,91 @@ final class CborCodingOptionsTests: XCTestCase {
 
     XCTAssertEqual(Data(writer.writeValue(value)).hexDescription, "a1a261610161620200")
   }
+
+  func testShortestFloatingPointEncodingSelectsSmallestExactWidth() throws {
+    let encoder = CborEncoder(options: .shortestFloatingPointEncoding)
+
+    XCTAssertEqual(try encoder.encode(Double(1.5)).hexDescription, "f93e00")
+    XCTAssertEqual(try encoder.encode(Double(1.1)).hexDescription, "fb3ff199999999999a")
+    XCTAssertEqual(try encoder.encode(Double(65_504)).hexDescription, "f97bff")
+    XCTAssertEqual(try encoder.encode(Double(100_000)).hexDescription, "fa47c35000")
+    XCTAssertEqual(try encoder.encode(Double(1_000_000.5)).hexDescription, "fa49742408")
+    XCTAssertEqual(try encoder.encode(Double(5.960464477539063e-8)).hexDescription, "f90001")
+    XCTAssertEqual(try encoder.encode(Double(0.00006103515625)).hexDescription, "f90400")
+    XCTAssertEqual(
+      try encoder.encode(Double.greatestFiniteMagnitude).hexDescription,
+      "fb7fefffffffffffff")
+  }
+
+  func testShortestFloatingPointEncodingHandlesSpecialValues() throws {
+    let encoder = CborEncoder(options: .shortestFloatingPointEncoding)
+
+    XCTAssertEqual(try encoder.encode(Double.zero).hexDescription, "f90000")
+    XCTAssertEqual(try encoder.encode(-Double.zero).hexDescription, "f98000")
+    XCTAssertEqual(try encoder.encode(Double.infinity).hexDescription, "f97c00")
+    XCTAssertEqual(try encoder.encode(-Double.infinity).hexDescription, "f9fc00")
+    XCTAssertEqual(try encoder.encode(Double.nan).hexDescription, "f97e00")
+    XCTAssertEqual(
+      try encoder.encode(Float(bitPattern: 0xFFC0_0000)).hexDescription,
+      "f9fe00")
+  }
+
+  func testShortestFloatingPointEncodingPreservesNaNRepresentations() throws {
+    let encoder = CborEncoder(options: .shortestFloatingPointEncoding)
+
+    XCTAssertEqual(
+      try encoder.encode(Float16(bitPattern: 0x7D01)).hexDescription,
+      "f97d01")
+    XCTAssertEqual(
+      try encoder.encode(Float(bitPattern: 0xFFC1_2345)).hexDescription,
+      "faffc12345")
+    XCTAssertEqual(
+      try encoder.encode(Double(bitPattern: 0x7FF8_0000_2000_0000)).hexDescription,
+      "fa7fc00001")
+    XCTAssertEqual(
+      try encoder.encode(Double(bitPattern: 0x7FF8_0000_0000_0001)).hexDescription,
+      "fb7ff8000000000001")
+  }
+
+  func testShortestFloatingPointEncodingPreservesEveryFloat16BitPattern() throws {
+    let encoder = CborEncoder(options: .shortestFloatingPointEncoding)
+
+    for bitPattern in UInt16.min...UInt16.max {
+      let expected = Data([
+        0xF9,
+        UInt8(truncatingIfNeeded: bitPattern >> 8),
+        UInt8(truncatingIfNeeded: bitPattern),
+      ])
+      let actual = try encoder.encode(Float16(bitPattern: bitPattern))
+      if actual != expected {
+        XCTFail(
+          "Float16 bit pattern \(String(bitPattern, radix: 16)) encoded as \(actual.hexDescription)"
+        )
+        return
+      }
+    }
+  }
+
+  func testDefaultEncoderPreservesFloatingPointSourceWidth() throws {
+    let encoder = CborEncoder()
+
+    XCTAssertEqual(try encoder.encode(Float16(1.5)).hexDescription, "f93e00")
+    XCTAssertEqual(try encoder.encode(Float(1.5)).hexDescription, "fa3fc00000")
+    XCTAssertEqual(try encoder.encode(Double(1.5)).hexDescription, "fb3ff8000000000000")
+  }
+
+  func testShortestFloatingPointEncodingCombinesWithRecursiveMapSorting() throws {
+    let options: CborEncoder.Options = [
+      .lexicographicallySortedMapKeys,
+      .shortestFloatingPointEncoding,
+    ]
+    let encoder = CborEncoder(options: options)
+
+    XCTAssertEqual(
+      try encoder.encode([
+        "b": [Double(2)],
+        "a": [Double(1.5)],
+      ]).hexDescription,
+      "a2616181f93e00616281f94000")
+  }
 }


### PR DESCRIPTION
This PR adds an option to encode CBOR floating-point values using the shortest representation that preserves the value.