### PR TITLE
feat: add deterministic CBOR option preset

### DIFF
--- a/Sources/SwiftCbor/CborDecoderOptions.swift
+++ b/Sources/SwiftCbor/CborDecoderOptions.swift
@@ -8,5 +8,19 @@ extension CborDecoder {
 
     public static let minimalArgumentEncoding = Options(rawValue: 1 << 0)
     public static let definiteLengthItems = Options(rawValue: 1 << 1)
+    public static let lexicographicallySortedMapKeys = Options(rawValue: 1 << 2)
+    public static let shortestFloatingPointEncoding = Options(rawValue: 1 << 3)
+
+    /// Validates the core deterministic encoding requirements in RFC 8949 Section 4.2.1.
+    ///
+    /// This option uses bytewise lexicographic map key ordering, not the length-first ordering in
+    /// Section 4.2.3. Protocol-specific choices described in Section 4.2.2, including tag usage,
+    /// numeric equivalence, and a single NaN representation, remain the application's responsibility.
+    public static let deterministicCbor: Options = [
+      .minimalArgumentEncoding,
+      .definiteLengthItems,
+      .lexicographicallySortedMapKeys,
+      .shortestFloatingPointEncoding,
+    ]
   }
 }

--- a/Sources/SwiftCbor/CborEncoderOptions.swift
+++ b/Sources/SwiftCbor/CborEncoderOptions.swift
@@ -8,5 +8,15 @@ extension CborEncoder {
 
     public static let lexicographicallySortedMapKeys = Options(rawValue: 1 << 0)
     public static let shortestFloatingPointEncoding = Options(rawValue: 1 << 1)
+
+    /// Applies the core deterministic encoding requirements in RFC 8949 Section 4.2.1.
+    ///
+    /// This option uses bytewise lexicographic map key ordering, not the length-first ordering in
+    /// Section 4.2.3. Signed zero and NaN payloads are preserved. Protocol-specific choices described
+    /// in Section 4.2.2 remain the application's responsibility.
+    public static let deterministicCbor: Options = [
+      .lexicographicallySortedMapKeys,
+      .shortestFloatingPointEncoding,
+    ]
   }
 }

--- a/Sources/SwiftCbor/CborScanner.swift
+++ b/Sources/SwiftCbor/CborScanner.swift
@@ -85,9 +85,13 @@ class CborScanner {
     case 0x19:
       return .literal(.float16(read(1 << 1)))
     case 0x1A:
-      return .literal(.float32(read(1 << 2)))
+      let bytes = read(1 << 2)
+      try requireShortestFloatingPointEncoding(bytes, as: Float.self)
+      return .literal(.float32(bytes))
     case 0x1B:
-      return .literal(.float64(read(1 << 3)))
+      let bytes = read(1 << 3)
+      try requireShortestFloatingPointEncoding(bytes, as: Double.self)
+      return .literal(.float64(bytes))
     case 0x1F:
       if options.contains(.definiteLengthItems) {
         throw DecodingError.dataCorrupted(
@@ -129,19 +133,26 @@ class CborScanner {
 
   private func scanMap(additional c: UInt8) throws -> CborValue {
     var a: [CborValue] = []
+    var previousKeyEncoding: Data?
     if let n = try getLength(c: c) {
       a.reserveCapacity(n)
       for _ in 0..<n {
+        let keyStart = off
         try a.append(scan())
+        try requireLexicographicallySortedMapKey(
+          data[keyStart..<off], after: &previousKeyEncoding)
         try a.append(scan())
       }
     } else {
       try rejectIndefiniteLengthItem("map")
       while true {
+        let keyStart = off
         let k = try scan()
         if case .literal(.break) = k {
           break
         }
+        try requireLexicographicallySortedMapKey(
+          data[keyStart..<off], after: &previousKeyEncoding)
         let v = try scan()
         if case .literal(.break) = k {
           break
@@ -151,6 +162,72 @@ class CborScanner {
       }
     }
     return .map(a)
+  }
+
+  private func requireLexicographicallySortedMapKey(
+    _ encoding: Data, after previousEncoding: inout Data?
+  ) throws {
+    guard options.contains(.lexicographicallySortedMapKeys) else { return }
+    if let previousEncoding, encoding.lexicographicallyPrecedes(previousEncoding) {
+      throw DecodingError.dataCorrupted(
+        .init(
+          codingPath: [],
+          debugDescription: "CBOR map keys are not in bytewise lexicographic order."
+        ))
+    }
+    previousEncoding = encoding
+  }
+
+  private func requireShortestFloatingPointEncoding<F: BinaryFloatingPoint & DataNumber>(
+    _ bytes: Data, as type: F.Type
+  ) throws {
+    guard options.contains(.shortestFloatingPointEncoding) else { return }
+    let value = try F(data: bytes)
+
+    let canNarrow: Bool
+    if value.isNaN {
+      canNarrow = canNarrowNaNSignificand(
+        UInt64(value.significandBitPattern), from: F.significandBitCount)
+    } else {
+      let double = Double(value)
+      let half = Float16(double)
+      if sameFloatingPointValue(Double(half), double) {
+        canNarrow = true
+      } else if F.self == Double.self {
+        let single = Float(double)
+        canNarrow = sameFloatingPointValue(Double(single), double)
+      } else {
+        canNarrow = false
+      }
+    }
+
+    guard !canNarrow else {
+      throw DecodingError.dataCorrupted(
+        .init(
+          codingPath: [],
+          debugDescription: "CBOR floating-point value does not use its shortest encoding."
+        ))
+    }
+  }
+
+  private func canNarrowNaNSignificand(_ significand: UInt64, from sourceWidth: Int) -> Bool {
+    canNarrowNaNSignificand(significand, from: sourceWidth, to: 10)
+      || (sourceWidth > 23
+        && canNarrowNaNSignificand(significand, from: sourceWidth, to: 23))
+  }
+
+  private func canNarrowNaNSignificand(
+    _ significand: UInt64, from sourceWidth: Int, to targetWidth: Int
+  ) -> Bool {
+    guard sourceWidth > targetWidth else { return false }
+    let discardedWidth = sourceWidth - targetWidth
+    let discardedMask = (UInt64(1) << discardedWidth) - 1
+    guard significand & discardedMask == 0 else { return false }
+    return significand >> discardedWidth != 0
+  }
+
+  private func sameFloatingPointValue(_ lhs: Double, _ rhs: Double) -> Bool {
+    lhs == rhs && (lhs != 0 || lhs.sign == rhs.sign)
   }
 
   private func rejectIndefiniteLengthItem(_ kind: String) throws {

--- a/Tests/SwiftCborTests/CborCodingOptionsTests.swift
+++ b/Tests/SwiftCborTests/CborCodingOptionsTests.swift
@@ -61,6 +61,21 @@ final class CborCodingOptionsTests: XCTestCase {
     XCTAssertEqual(try CborDecoder().decode(UInt8.self, from: Data(hex: "1817")), 23)
   }
 
+  func testDeterministicCborRejectsNonMinimalArgumentsForEveryApplicableMajorType() {
+    for hex in [
+      "1817",  // unsigned integer
+      "3817",  // negative integer
+      "5800",  // byte string length
+      "7800",  // text string length
+      "9800",  // array length
+      "b800",  // map length
+      "d80000",  // tag number
+    ] {
+      XCTAssertThrowsError(
+        try CborScanner(data: Data(hex: hex), options: .deterministicCbor).scan(), hex)
+    }
+  }
+
   func testDefiniteLengthItemsRejectsIndefiniteArray() {
     let decoder = CborDecoder(options: .definiteLengthItems)
     XCTAssertThrowsError(try decoder.decode([Int].self, from: Data(hex: "9f0102ff")))
@@ -73,6 +88,68 @@ final class CborCodingOptionsTests: XCTestCase {
 
   func testDefaultDecoderAcceptsIndefiniteArray() throws {
     XCTAssertEqual(try CborDecoder().decode([Int].self, from: Data(hex: "9f0102ff")), [1, 2])
+  }
+
+  func testDeterministicCborRejectsEveryIndefiniteLengthItem() {
+    for hex in [
+      "5fff",  // byte string
+      "7fff",  // text string
+      "9fff",  // array
+      "bfff",  // map
+      "819fff",  // nested array
+    ] {
+      XCTAssertThrowsError(
+        try CborScanner(data: Data(hex: hex), options: .deterministicCbor).scan(), hex)
+    }
+  }
+
+  func testLexicographicallySortedMapKeysRejectsUnsortedMapsRecursively() throws {
+    let decoder = CborDecoder(options: .lexicographicallySortedMapKeys)
+
+    XCTAssertThrowsError(
+      try decoder.decode([String: Int].self, from: Data(hex: "a2616201616102")))
+    XCTAssertThrowsError(
+      try decoder.decode([String: [String: Int]].self, from: Data(hex: "a16161a2616201616102")))
+    XCTAssertThrowsError(
+      try decoder.decode([String: Int].self, from: Data(hex: "bf616201616102ff")))
+  }
+
+  func testLexicographicallySortedMapKeysAllowsSortedKeys() throws {
+    let options = CborDecoder.Options.lexicographicallySortedMapKeys
+
+    XCTAssertNoThrow(
+      try CborDecoder(options: options).decode(
+        [String: Int].self, from: Data(hex: "a2616101616202")))
+  }
+
+  func testLexicographicallySortedMapKeysDoesNotValidateDuplicateKeys() throws {
+    let options = CborDecoder.Options.lexicographicallySortedMapKeys
+
+    XCTAssertNoThrow(try CborScanner(data: Data(hex: "a2616101616102"), options: options).scan())
+  }
+
+  func testDeterministicCborUsesRfc8949BytewiseMapKeyOrder() throws {
+    let coreOrder = Data(
+      hex: "a80af61864f620f6617af6626161f6811864f68120f6f4f6")
+    let lengthFirstOrder = Data(
+      hex: "a80af620f6f4f61864f6617af68120f6626161f6811864f6")
+
+    XCTAssertNoThrow(try CborScanner(data: coreOrder, options: .deterministicCbor).scan())
+    XCTAssertThrowsError(
+      try CborScanner(data: lengthFirstOrder, options: .deterministicCbor).scan())
+  }
+
+  func testDeterministicCborValidatesMapOrderWithinCompositeKeys() {
+    XCTAssertThrowsError(
+      try CborScanner(
+        data: Data(hex: "a1a261620061610000"), options: .deterministicCbor
+      ).scan())
+  }
+
+  func testDefaultDecoderAcceptsUnsortedMapKeys() throws {
+    XCTAssertEqual(
+      try CborDecoder().decode([String: Int].self, from: Data(hex: "a2616201616102")),
+      ["a": 2, "b": 1])
   }
 
   func testLexicographicallySortedMapKeysSortsRecursively() throws {
@@ -200,6 +277,69 @@ final class CborCodingOptionsTests: XCTestCase {
     XCTAssertEqual(try encoder.encode(Double(1.5)).hexDescription, "fb3ff8000000000000")
   }
 
+  func testShortestFloatingPointDecodingRejectsValuesThatCanNarrow() {
+    let decoder = CborDecoder(options: .shortestFloatingPointEncoding)
+
+    for hex in [
+      "fa3fc00000",  // 1.5 as Float32
+      "fb3ff8000000000000",  // 1.5 as Float64
+      "fa00000000",  // positive zero as Float32
+      "fa7f800000",  // infinity as Float32
+      "fb0000000000000000",  // positive zero as Float64
+      "fb8000000000000000",  // negative zero as Float64
+      "fb7ff0000000000000",  // infinity as Float64
+      "fbfff0000000000000",  // -infinity as Float64
+      "fa80000000",  // negative zero as Float32
+      "fa33800000",  // the smallest Float16 subnormal as Float32
+      "fb36a0000000000000",  // the smallest Float32 subnormal as Float64
+      "fa7fc02000",  // NaN with a payload that fits in Float16
+      "faffc02000",  // negative NaN with a payload that fits in Float16
+      "fb7ff8000020000000",  // NaN with a payload that fits in Float32
+    ] {
+      XCTAssertThrowsError(try decoder.decode(Double.self, from: Data(hex: hex)), hex)
+    }
+  }
+
+  func testShortestFloatingPointDecodingAcceptsValuesThatCannotNarrow() throws {
+    let decoder = CborDecoder(options: .shortestFloatingPointEncoding)
+
+    XCTAssertEqual(
+      try decoder.decode(Float.self, from: Data(hex: "fa3f8ccccd")),
+      Float(bitPattern: 0x3F8C_CCCD))
+    XCTAssertEqual(
+      try decoder.decode(Double.self, from: Data(hex: "fb3ff199999999999a")), 1.1)
+    XCTAssertEqual(
+      try decoder.decode(Float.self, from: Data(hex: "fa00000001")).bitPattern, 1)
+    XCTAssertEqual(
+      try decoder.decode(Double.self, from: Data(hex: "fb0000000000000001")).bitPattern, 1)
+    XCTAssertTrue(
+      try decoder.decode(Float.self, from: Data(hex: "faffc12345")).isNaN)
+    XCTAssertTrue(
+      try decoder.decode(Float.self, from: Data(hex: "fa7f800001")).isNaN)
+    XCTAssertTrue(
+      try decoder.decode(Double.self, from: Data(hex: "fb7ff8000000000001")).isNaN)
+    XCTAssertTrue(
+      try decoder.decode(Double.self, from: Data(hex: "fb7ff0000000000001")).isNaN)
+  }
+
+  func testShortestFloatingPointDecodingAcceptsEveryFloat16BitPattern() throws {
+    let options = CborDecoder.Options.shortestFloatingPointEncoding
+
+    for bitPattern in UInt16.min...UInt16.max {
+      let data = Data([
+        0xF9,
+        UInt8(truncatingIfNeeded: bitPattern >> 8),
+        UInt8(truncatingIfNeeded: bitPattern),
+      ])
+      XCTAssertNoThrow(try CborScanner(data: data, options: options).scan())
+    }
+  }
+
+  func testDefaultDecoderAcceptsNonShortestFloatingPointEncoding() throws {
+    XCTAssertEqual(
+      try CborDecoder().decode(Double.self, from: Data(hex: "fb3ff8000000000000")), 1.5)
+  }
+
   func testShortestFloatingPointEncodingCombinesWithRecursiveMapSorting() throws {
     let options: CborEncoder.Options = [
       .lexicographicallySortedMapKeys,
@@ -213,5 +353,32 @@ final class CborCodingOptionsTests: XCTestCase {
         "a": [Double(1.5)],
       ]).hexDescription,
       "a2616181f93e00616281f94000")
+  }
+
+  func testDeterministicCborContainsCoreOptions() {
+    XCTAssertTrue(CborEncoder.Options.deterministicCbor.contains(.lexicographicallySortedMapKeys))
+    XCTAssertTrue(CborEncoder.Options.deterministicCbor.contains(.shortestFloatingPointEncoding))
+    XCTAssertTrue(CborDecoder.Options.deterministicCbor.contains(.minimalArgumentEncoding))
+    XCTAssertTrue(CborDecoder.Options.deterministicCbor.contains(.definiteLengthItems))
+    XCTAssertTrue(
+      CborDecoder.Options.deterministicCbor.contains(.lexicographicallySortedMapKeys))
+    XCTAssertTrue(
+      CborDecoder.Options.deterministicCbor.contains(.shortestFloatingPointEncoding))
+  }
+
+  func testDeterministicCborIntegratesCoreRules() throws {
+    let encoder = CborEncoder(options: .deterministicCbor)
+    let input = ["b": 2.0, "a": 1.5]
+    let encoded = try encoder.encode(input)
+    XCTAssertEqual(
+      encoded.hexDescription, "a26161f93e006162f94000")
+
+    let decoder = CborDecoder(options: .deterministicCbor)
+    XCTAssertEqual(try decoder.decode([String: Double].self, from: encoded), input)
+    XCTAssertThrowsError(try decoder.decode(UInt8.self, from: Data(hex: "1817")))
+    XCTAssertThrowsError(try decoder.decode([Int].self, from: Data(hex: "9f01ff")))
+    XCTAssertThrowsError(
+      try decoder.decode([String: Int].self, from: Data(hex: "a2616201616102")))
+    XCTAssertThrowsError(try decoder.decode(Double.self, from: Data(hex: "fa3fc00000")))
   }
 }


### PR DESCRIPTION
This PR adds `.deterministicCbor` option presets for encoding and validating the core deterministic encoding requirements in RFC 8949 Section 4.2.1:

- combines bytewise lexicographic map key ordering and shortest floating-point encoding for `CborEncoder`
- combines minimal argument encoding, definite-length items, bytewise lexicographic map key ordering, and shortest floating-point encoding for `CborDecoder`
- validates map key ordering and shortest floating-point representations during decoding
- documents the protocol-specific deterministic encoding decisions that remain the application's responsibility