### PR TITLE
fix: normalize CborScanner buffer to avoid non-zero startIndex crash

### DIFF
--- a/Sources/SwiftCbor/CborScanner.swift
+++ b/Sources/SwiftCbor/CborScanner.swift
@@ -7,7 +7,7 @@ class CborScanner {
 
   init(data: Data, options: CborDecoder.Options = []) {
     self.data = data
-    off = 0
+    off = data.startIndex
     self.options = options
   }
 
@@ -292,7 +292,7 @@ class CborScanner {
   }
 
   private func readOpCode() -> CborOpCode {
-    if off < data.count {
+    if off < data.endIndex {
       defer {
         off += 1
       }

--- a/Tests/SwiftCborTests/DecodeTests.swift
+++ b/Tests/SwiftCborTests/DecodeTests.swift
@@ -148,6 +148,21 @@ final class DecodeTests: XCTestCase {
     XCTAssertEqual(
       try decoder.decode(UInt64.self, from: Data(hex: "1bffffffffffffffff")), UInt64.max)
   }
+
+  func testDecodeExtractedDataField() throws {
+    struct Inner: Codable, Equatable {
+      let value: Int
+    }
+    struct Outer: Codable {
+      let inner: Data
+    }
+
+    let innerBytes = try CborEncoder().encode(Inner(value: 7))
+    let outerBytes = try CborEncoder().encode(Outer(inner: innerBytes))
+    let decodedOuter = try decoder.decode(Outer.self, from: outerBytes)
+
+    XCTAssertEqual(try decoder.decode(Inner.self, from: decodedOuter.inner), Inner(value: 7))
+  }
 }
 
 extension UnicodeScalar {


### PR DESCRIPTION
Decoding a `Data` value that was itself produced by an earlier decode, such as CBOR nested inside a `Data` field, could crash with `EXC_BREAKPOINT`. This has been fixed, and a regression test covering the case has been added.

Closes #13