### PR TITLE
feat: add string-only CBOR map key option

### DIFF
--- a/Sources/SwiftCbor/CborDecoderOptions.swift
+++ b/Sources/SwiftCbor/CborDecoderOptions.swift
@@ -10,6 +10,7 @@ extension CborDecoder {
     public static let definiteLengthItems = Options(rawValue: 1 << 1)
     public static let lexicographicallySortedMapKeys = Options(rawValue: 1 << 2)
     public static let shortestFloatingPointEncoding = Options(rawValue: 1 << 3)
+    public static let stringMapKeysOnly = Options(rawValue: 1 << 4)
 
     /// Validates the core deterministic encoding requirements in RFC 8949 Section 4.2.1.
     ///

--- a/Sources/SwiftCbor/CborScanner.swift
+++ b/Sources/SwiftCbor/CborScanner.swift
@@ -138,9 +138,17 @@ class CborScanner {
       a.reserveCapacity(n)
       for _ in 0..<n {
         let keyStart = off
-        try a.append(scan())
+        let key = try scan()
         try requireLexicographicallySortedMapKey(
           data[keyStart..<off], after: &previousKeyEncoding)
+        if options.contains(.stringMapKeysOnly), !key.isTextString {
+          throw DecodingError.dataCorrupted(
+            .init(
+              codingPath: [],
+              debugDescription: "CBOR map keys must be text strings."
+            ))
+        }
+        a.append(key)
         try a.append(scan())
       }
     } else {
@@ -153,6 +161,13 @@ class CborScanner {
         }
         try requireLexicographicallySortedMapKey(
           data[keyStart..<off], after: &previousKeyEncoding)
+        if options.contains(.stringMapKeysOnly), !k.isTextString {
+          throw DecodingError.dataCorrupted(
+            .init(
+              codingPath: [],
+              debugDescription: "CBOR map keys must be text strings."
+            ))
+        }
         let v = try scan()
         if case .literal(.break) = k {
           break
@@ -300,5 +315,12 @@ class CborScanner {
     } else {
       return .end
     }
+  }
+}
+
+extension CborValue {
+  fileprivate var isTextString: Bool {
+    if case .literal(.str) = self { return true }
+    return false
   }
 }

--- a/Tests/SwiftCborTests/CborCodingOptionsTests.swift
+++ b/Tests/SwiftCborTests/CborCodingOptionsTests.swift
@@ -381,4 +381,14 @@ final class CborCodingOptionsTests: XCTestCase {
       try decoder.decode([String: Int].self, from: Data(hex: "a2616201616102")))
     XCTAssertThrowsError(try decoder.decode(Double.self, from: Data(hex: "fa3fc00000")))
   }
+
+  func testStringMapKeysOnlyRejectsOtherKeyTypes() {
+    let decoder = CborDecoder(options: .stringMapKeysOnly)
+    XCTAssertThrowsError(try decoder.decode([String: Int].self, from: Data(hex: "a10102")))
+  }
+
+  func testStringMapKeysOnlyAcceptsTextKeys() throws {
+    let decoder = CborDecoder(options: .stringMapKeysOnly)
+    XCTAssertEqual(try decoder.decode([String: Int].self, from: Data(hex: "a1616101")), ["a": 1])
+  }
 }


### PR DESCRIPTION
This PR adds an option that rejects CBOR maps whose keys are not text strings during decoding.