### PR TITLE
feat: add basic CBOR simple values only decoder option

### DIFF
--- a/Sources/SwiftCbor/CborDecoder.swift
+++ b/Sources/SwiftCbor/CborDecoder.swift
@@ -79,13 +79,16 @@ private class _CborDecoder: Decoder {
 extension _CborDecoder {
   @inline(__always)
   fileprivate func checkNotNull<T>(_ type: CborValueLiteralType, expectedType: T.Type) throws {
-    if case .nil = type {
+    switch type {
+    case .nil, .undefined:
       throw DecodingError.valueNotFound(
         expectedType,
         DecodingError.Context(
           codingPath: codingPath,
           debugDescription: "Cannot get value of type \(expectedType) -- found null value instead"
         ))
+    default:
+      break
     }
   }
 
@@ -439,9 +442,10 @@ private struct _CborSingleValueDecodingContainer: SingleValueDecodingContainer {
   }
 
   func decodeNil() -> Bool {
-    if case .literal(.nil) = value {
+    switch value {
+    case .literal(.nil), .literal(.undefined):
       true
-    } else {
+    default:
       false
     }
   }
@@ -530,11 +534,13 @@ private struct CborUnkeyedUnkeyedDecodingContainer: UnkeyedDecodingContainer {
 
   mutating func decodeNil() throws -> Bool {
     let value = try getNextValue(ofType: Never.self)
-    if case .literal(.nil) = value {
+    switch value {
+    case .literal(.nil), .literal(.undefined):
       currentIndex += 1
       return true
+    default:
+      return false
     }
-    return false
   }
 
   mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws
@@ -795,9 +801,10 @@ private struct CborKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerP
 
   func decodeNil(forKey key: Key) throws -> Bool {
     let value = try getValue(forKey: key)
-    if case .literal(.nil) = value {
+    switch value {
+    case .literal(.nil), .literal(.undefined):
       return true
-    } else {
+    default:
       return false
     }
   }

--- a/Sources/SwiftCbor/CborDecoderOptions.swift
+++ b/Sources/SwiftCbor/CborDecoderOptions.swift
@@ -11,6 +11,7 @@ extension CborDecoder {
     public static let lexicographicallySortedMapKeys = Options(rawValue: 1 << 2)
     public static let shortestFloatingPointEncoding = Options(rawValue: 1 << 3)
     public static let stringMapKeysOnly = Options(rawValue: 1 << 4)
+    public static let basicSimpleValuesOnly = Options(rawValue: 1 << 5)
 
     /// Validates the core deterministic encoding requirements in RFC 8949 Section 4.2.1.
     ///

--- a/Sources/SwiftCbor/CborScanner.swift
+++ b/Sources/SwiftCbor/CborScanner.swift
@@ -73,6 +73,7 @@ class CborScanner {
   private func scanFloat(additional c: UInt8) throws -> CborValue {
     switch c {
     case 0x00...0x13:
+      if options.contains(.basicSimpleValuesOnly) { throw unsupportedSimpleValue(c) }
       return .literal(.simple(c))
     case 0x14:
       return .literal(.bool(false))
@@ -81,9 +82,12 @@ class CborScanner {
     case 0x16:
       return .literal(.nil)
     case 0x17:
+      if options.contains(.basicSimpleValuesOnly) { throw unsupportedSimpleValue(c) }
       return .literal(.undefined)
     case 0x18:
-      return .literal(.simple(bigEndianFixedWidthInt(read(1 << 0), as: UInt8.self)))
+      let value: UInt8 = bigEndianFixedWidthInt(read(1 << 0), as: UInt8.self)
+      if options.contains(.basicSimpleValuesOnly) { throw unsupportedSimpleValue(value) }
+      return .literal(.simple(value))
     case 0x19:
       return .literal(.float16(read(1 << 1)))
     case 0x1A:
@@ -107,6 +111,14 @@ class CborScanner {
     default:
       return .none
     }
+  }
+
+  private func unsupportedSimpleValue(_ value: UInt8) -> DecodingError {
+    DecodingError.dataCorrupted(
+      .init(
+        codingPath: [],
+        debugDescription: "CBOR simple value \(value) is not false, true, or null."
+      ))
   }
 
   private func scanTaggedValue(additional c: UInt8) throws -> CborValue {

--- a/Sources/SwiftCbor/CborScanner.swift
+++ b/Sources/SwiftCbor/CborScanner.swift
@@ -73,15 +73,17 @@ class CborScanner {
   private func scanFloat(additional c: UInt8) throws -> CborValue {
     switch c {
     case 0x00...0x13:
-      return .literal(.uint(UInt64(c)))
+      return .literal(.simple(c))
     case 0x14:
       return .literal(.bool(false))
     case 0x15:
       return .literal(.bool(true))
-    case 0x16, 0x17:
+    case 0x16:
       return .literal(.nil)
+    case 0x17:
+      return .literal(.undefined)
     case 0x18:
-      return .literal(.uint(UInt64(bigEndianFixedWidthInt(read(1 << 0), as: UInt8.self))))
+      return .literal(.simple(bigEndianFixedWidthInt(read(1 << 0), as: UInt8.self)))
     case 0x19:
       return .literal(.float16(read(1 << 1)))
     case 0x1A:

--- a/Sources/SwiftCbor/CborValue.swift
+++ b/Sources/SwiftCbor/CborValue.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum CborValueLiteralType {
+enum CborValueLiteralType: Sendable {
   case `nil`
   case undefined
   case simple(UInt8)
@@ -87,7 +87,7 @@ struct CborStringKey {
   let CborValue: CborEncodedValue
 }
 
-indirect enum CborValue {
+indirect enum CborValue: Sendable {
   case none
   case literal(CborValueLiteralType)
   case array([CborValue])

--- a/Sources/SwiftCbor/CborValue.swift
+++ b/Sources/SwiftCbor/CborValue.swift
@@ -2,6 +2,8 @@ import Foundation
 
 enum CborValueLiteralType {
   case `nil`
+  case undefined
+  case simple(UInt8)
   case `break`
   case bool(Bool)
   case int(UInt64)
@@ -18,6 +20,10 @@ extension CborValueLiteralType {
     switch self {
     case .nil:
       "nil"
+    case .undefined:
+      "undefined"
+    case .simple:
+      "simple"
     case .break:
       "break"
     case .bool:

--- a/Tests/SwiftCborTests/CborCodingOptionsTests.swift
+++ b/Tests/SwiftCborTests/CborCodingOptionsTests.swift
@@ -402,4 +402,18 @@ final class CborCodingOptionsTests: XCTestCase {
   func testDefaultDecoderKeepsUndefinedAsNull() throws {
     XCTAssertNil(try CborDecoder().decode(String?.self, from: Data(hex: "f7")))
   }
+
+  func testBasicSimpleValuesOnlyRejectsUndefinedAndOtherSimpleValues() {
+    let decoder = CborDecoder(options: .basicSimpleValuesOnly)
+    XCTAssertThrowsError(try decoder.decode(String?.self, from: Data(hex: "f7")))
+    XCTAssertThrowsError(try decoder.decode(Int.self, from: Data(hex: "f0")))
+    XCTAssertThrowsError(try decoder.decode(Int.self, from: Data(hex: "f820")))
+  }
+
+  func testBasicSimpleValuesOnlyAcceptsBoolAndNull() throws {
+    let decoder = CborDecoder(options: .basicSimpleValuesOnly)
+    XCTAssertEqual(try decoder.decode(Bool.self, from: Data(hex: "f4")), false)
+    XCTAssertEqual(try decoder.decode(Bool.self, from: Data(hex: "f5")), true)
+    XCTAssertNil(try decoder.decode(String?.self, from: Data(hex: "f6")))
+  }
 }

--- a/Tests/SwiftCborTests/CborCodingOptionsTests.swift
+++ b/Tests/SwiftCborTests/CborCodingOptionsTests.swift
@@ -391,4 +391,15 @@ final class CborCodingOptionsTests: XCTestCase {
     let decoder = CborDecoder(options: .stringMapKeysOnly)
     XCTAssertEqual(try decoder.decode([String: Int].self, from: Data(hex: "a1616101")), ["a": 1])
   }
+
+  func testMajorType7SimpleValuesAreNotIntegers() {
+    let decoder = CborDecoder()
+    XCTAssertThrowsError(try decoder.decode(Int.self, from: Data(hex: "f0")))
+    XCTAssertThrowsError(try decoder.decode(Int.self, from: Data(hex: "f3")))
+    XCTAssertThrowsError(try decoder.decode(Int.self, from: Data(hex: "f820")))
+  }
+
+  func testDefaultDecoderKeepsUndefinedAsNull() throws {
+    XCTAssertNil(try CborDecoder().decode(String?.self, from: Data(hex: "f7")))
+  }
 }


### PR DESCRIPTION
This PR adds an option that rejects any CBOR simple value other than false, true, and null, along with the underlying decoder fix that surfaced while wiring it up:

- fixes decoding of CBOR major type 7 per RFC 8949 §3.3: additional-info 0..19 and the `0x18 XX` two-byte form now decode as `.simple` (previously misinterpreted as unsigned integers) and `0x17` decodes as `.undefined` (previously coerced to null)
- collapses `.undefined` into null at the Codable Optional and nil-container boundaries so existing round trips still work
- adds `.basicSimpleValuesOnly` to `CborDecoder.Options` and enforces it recursively in the scanner
- marks `CborValue` and `CborValueLiteralType` as `Sendable`