### PR TITLE
feat: add finite CBOR floating-point option

### DIFF
--- a/Sources/SwiftCbor/CborDecoderOptions.swift
+++ b/Sources/SwiftCbor/CborDecoderOptions.swift
@@ -12,6 +12,7 @@ extension CborDecoder {
     public static let shortestFloatingPointEncoding = Options(rawValue: 1 << 3)
     public static let stringMapKeysOnly = Options(rawValue: 1 << 4)
     public static let basicSimpleValuesOnly = Options(rawValue: 1 << 5)
+    public static let finiteFloatingPointValuesOnly = Options(rawValue: 1 << 6)
 
     /// Validates the core deterministic encoding requirements in RFC 8949 Section 4.2.1.
     ///

--- a/Sources/SwiftCbor/CborEncoder.swift
+++ b/Sources/SwiftCbor/CborEncoder.swift
@@ -271,6 +271,15 @@ extension _SpecialTreatmentEncoder {
   fileprivate func wrapFloat<F: BinaryFloatingPoint & DataNumber>(
     _ value: F, for additionalKey: CodingKey?
   ) throws -> CborEncodedValue {
+    if encoder.options.contains(.finiteFloatingPointValuesOnly), !value.isFinite {
+      let path = additionalKey.map { codingPath + [$0] } ?? codingPath
+      throw EncodingError.invalidValue(
+        value,
+        .init(
+          codingPath: path,
+          debugDescription: "Non-finite floating-point values are not permitted."
+        ))
+    }
     if encoder.options.contains(.shortestFloatingPointEncoding) {
       return shortestFloatingPointValue(value)
     }

--- a/Sources/SwiftCbor/CborEncoderOptions.swift
+++ b/Sources/SwiftCbor/CborEncoderOptions.swift
@@ -8,6 +8,7 @@ extension CborEncoder {
 
     public static let lexicographicallySortedMapKeys = Options(rawValue: 1 << 0)
     public static let shortestFloatingPointEncoding = Options(rawValue: 1 << 1)
+    public static let finiteFloatingPointValuesOnly = Options(rawValue: 1 << 2)
 
     /// Applies the core deterministic encoding requirements in RFC 8949 Section 4.2.1.
     ///

--- a/Sources/SwiftCbor/CborScanner.swift
+++ b/Sources/SwiftCbor/CborScanner.swift
@@ -89,13 +89,23 @@ class CborScanner {
       if options.contains(.basicSimpleValuesOnly) { throw unsupportedSimpleValue(value) }
       return .literal(.simple(value))
     case 0x19:
-      return .literal(.float16(read(1 << 1)))
+      let bytes = read(1 << 1)
+      if options.contains(.finiteFloatingPointValuesOnly), try !Float16(data: bytes).isFinite {
+        throw nonFiniteFloatError()
+      }
+      return .literal(.float16(bytes))
     case 0x1A:
       let bytes = read(1 << 2)
+      if options.contains(.finiteFloatingPointValuesOnly), try !Float(data: bytes).isFinite {
+        throw nonFiniteFloatError()
+      }
       try requireShortestFloatingPointEncoding(bytes, as: Float.self)
       return .literal(.float32(bytes))
     case 0x1B:
       let bytes = read(1 << 3)
+      if options.contains(.finiteFloatingPointValuesOnly), try !Double(data: bytes).isFinite {
+        throw nonFiniteFloatError()
+      }
       try requireShortestFloatingPointEncoding(bytes, as: Double.self)
       return .literal(.float64(bytes))
     case 0x1F:
@@ -118,6 +128,14 @@ class CborScanner {
       .init(
         codingPath: [],
         debugDescription: "CBOR simple value \(value) is not false, true, or null."
+      ))
+  }
+
+  private func nonFiniteFloatError() -> DecodingError {
+    DecodingError.dataCorrupted(
+      .init(
+        codingPath: [],
+        debugDescription: "Non-finite floating-point values are not permitted."
       ))
   }
 

--- a/Tests/SwiftCborTests/CborCodingOptionsTests.swift
+++ b/Tests/SwiftCborTests/CborCodingOptionsTests.swift
@@ -416,4 +416,23 @@ final class CborCodingOptionsTests: XCTestCase {
     XCTAssertEqual(try decoder.decode(Bool.self, from: Data(hex: "f5")), true)
     XCTAssertNil(try decoder.decode(String?.self, from: Data(hex: "f6")))
   }
+
+  func testFiniteFloatingPointValuesOnlyRejectsNonFiniteValues() {
+    let encoder = CborEncoder(options: .finiteFloatingPointValuesOnly)
+    XCTAssertThrowsError(try encoder.encode(Double.nan))
+    XCTAssertThrowsError(try encoder.encode(Double.infinity))
+    XCTAssertThrowsError(try encoder.encode(-Double.infinity))
+
+    let decoder = CborDecoder(options: .finiteFloatingPointValuesOnly)
+    XCTAssertThrowsError(try decoder.decode(Float16.self, from: Data(hex: "f97e00")))
+    XCTAssertThrowsError(try decoder.decode(Float.self, from: Data(hex: "fa7f800000")))
+    XCTAssertThrowsError(try decoder.decode(Double.self, from: Data(hex: "fbfff0000000000000")))
+  }
+
+  func testFiniteFloatingPointValuesOnlyAcceptsEveryFiniteWidth() throws {
+    let decoder = CborDecoder(options: .finiteFloatingPointValuesOnly)
+    XCTAssertEqual(try decoder.decode(Float16.self, from: Data(hex: "f93e00")), 1.5)
+    XCTAssertEqual(try decoder.decode(Float.self, from: Data(hex: "fa3fc00000")), 1.5)
+    XCTAssertEqual(try decoder.decode(Double.self, from: Data(hex: "fb3ff8000000000000")), 1.5)
+  }
 }

--- a/Tests/SwiftCborTests/CborCodingOptionsTests.swift
+++ b/Tests/SwiftCborTests/CborCodingOptionsTests.swift
@@ -435,4 +435,30 @@ final class CborCodingOptionsTests: XCTestCase {
     XCTAssertEqual(try decoder.decode(Float.self, from: Data(hex: "fa3fc00000")), 1.5)
     XCTAssertEqual(try decoder.decode(Double.self, from: Data(hex: "fb3ff8000000000000")), 1.5)
   }
+
+  func testFiniteFloatingPointValuesOnlyAcceptsSignedZeroAndBoundaryValues() throws {
+    let encoder = CborEncoder(options: .finiteFloatingPointValuesOnly)
+    XCTAssertNoThrow(try encoder.encode(-0.0))
+    XCTAssertNoThrow(try encoder.encode(Double.leastNonzeroMagnitude))
+    XCTAssertNoThrow(try encoder.encode(Double.greatestFiniteMagnitude))
+  }
+
+  func testFiniteFloatingPointValuesOnlyRejectsSignalingNaN() {
+    let encoder = CborEncoder(options: .finiteFloatingPointValuesOnly)
+    XCTAssertThrowsError(try encoder.encode(Double.signalingNaN))
+    XCTAssertThrowsError(try encoder.encode(Float.signalingNaN))
+  }
+
+  func testFiniteFloatingPointValuesOnlyRejectsFloat16NonFiniteValues() {
+    let encoder = CborEncoder(options: .finiteFloatingPointValuesOnly)
+    XCTAssertThrowsError(try encoder.encode(Float16.nan))
+    XCTAssertThrowsError(try encoder.encode(Float16.infinity))
+  }
+
+  func testFiniteFloatingPointValuesOnlyCombinesWithShortestFloatingPointEncoding() throws {
+    let encoder = CborEncoder(
+      options: [.finiteFloatingPointValuesOnly, .shortestFloatingPointEncoding])
+    XCTAssertEqual(try encoder.encode(Double(1.5)).hexDescription, "f93e00")
+    XCTAssertThrowsError(try encoder.encode(Double.nan))
+  }
 }


### PR DESCRIPTION
This PR adds an option that rejects non-finite CBOR floating-point values on both encode and decode sides.