### PR TITLE
feat: add 64-bit CBOR floating-point option

### DIFF
--- a/Sources/SwiftCbor/CborDecoder.swift
+++ b/Sources/SwiftCbor/CborDecoder.swift
@@ -16,6 +16,14 @@ open class CborDecoder {
   }
 
   open func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+    guard !options.hasConflictingFloatingPointOptions else {
+      throw DecodingError.dataCorrupted(
+        .init(
+          codingPath: [],
+          debugDescription:
+            "shortestFloatingPointEncoding and floatingPoint64Only cannot be combined."
+        ))
+    }
     let scanner = CborScanner(data: data, options: options)
     let value = try scanner.scan()
     let decoder: _CborDecoder = .init(from: value)

--- a/Sources/SwiftCbor/CborDecoderOptions.swift
+++ b/Sources/SwiftCbor/CborDecoderOptions.swift
@@ -13,6 +13,11 @@ extension CborDecoder {
     public static let stringMapKeysOnly = Options(rawValue: 1 << 4)
     public static let basicSimpleValuesOnly = Options(rawValue: 1 << 5)
     public static let finiteFloatingPointValuesOnly = Options(rawValue: 1 << 6)
+    public static let floatingPoint64Only = Options(rawValue: 1 << 7)
+
+    var hasConflictingFloatingPointOptions: Bool {
+      contains(.shortestFloatingPointEncoding) && contains(.floatingPoint64Only)
+    }
 
     /// Validates the core deterministic encoding requirements in RFC 8949 Section 4.2.1.
     ///

--- a/Sources/SwiftCbor/CborEncoder.swift
+++ b/Sources/SwiftCbor/CborEncoder.swift
@@ -12,6 +12,15 @@ open class CborEncoder {
   }
 
   open func encode(_ value: some Encodable) throws -> Data {
+    guard !options.hasConflictingFloatingPointOptions else {
+      throw EncodingError.invalidValue(
+        value,
+        .init(
+          codingPath: [],
+          debugDescription:
+            "shortestFloatingPointEncoding and floatingPoint64Only cannot be combined."
+        ))
+    }
     let value: CborEncodedValue = try encodeAsCborValue(value)
     let writer = CborValue.Writer(
       sortMapKeysLexicographically: options.contains(.lexicographicallySortedMapKeys)
@@ -282,6 +291,9 @@ extension _SpecialTreatmentEncoder {
     }
     if encoder.options.contains(.shortestFloatingPointEncoding) {
       return shortestFloatingPointValue(value)
+    }
+    if encoder.options.contains(.floatingPoint64Only) {
+      return .literal([0xFB] + Double(value).bytes)
     }
     let bits = value.bytes
     if bits.count == 2 {

--- a/Sources/SwiftCbor/CborEncoderOptions.swift
+++ b/Sources/SwiftCbor/CborEncoderOptions.swift
@@ -9,6 +9,11 @@ extension CborEncoder {
     public static let lexicographicallySortedMapKeys = Options(rawValue: 1 << 0)
     public static let shortestFloatingPointEncoding = Options(rawValue: 1 << 1)
     public static let finiteFloatingPointValuesOnly = Options(rawValue: 1 << 2)
+    public static let floatingPoint64Only = Options(rawValue: 1 << 3)
+
+    var hasConflictingFloatingPointOptions: Bool {
+      contains(.shortestFloatingPointEncoding) && contains(.floatingPoint64Only)
+    }
 
     /// Applies the core deterministic encoding requirements in RFC 8949 Section 4.2.1.
     ///

--- a/Sources/SwiftCbor/CborScanner.swift
+++ b/Sources/SwiftCbor/CborScanner.swift
@@ -90,12 +90,14 @@ class CborScanner {
       return .literal(.simple(value))
     case 0x19:
       let bytes = read(1 << 1)
+      if options.contains(.floatingPoint64Only) { throw requireFloat64Error() }
       if options.contains(.finiteFloatingPointValuesOnly), try !Float16(data: bytes).isFinite {
         throw nonFiniteFloatError()
       }
       return .literal(.float16(bytes))
     case 0x1A:
       let bytes = read(1 << 2)
+      if options.contains(.floatingPoint64Only) { throw requireFloat64Error() }
       if options.contains(.finiteFloatingPointValuesOnly), try !Float(data: bytes).isFinite {
         throw nonFiniteFloatError()
       }
@@ -136,6 +138,14 @@ class CborScanner {
       .init(
         codingPath: [],
         debugDescription: "Non-finite floating-point values are not permitted."
+      ))
+  }
+
+  private func requireFloat64Error() -> DecodingError {
+    DecodingError.dataCorrupted(
+      .init(
+        codingPath: [],
+        debugDescription: "Floating-point values must use the 64-bit representation."
       ))
   }
 

--- a/Tests/SwiftCborTests/CborCodingOptionsTests.swift
+++ b/Tests/SwiftCborTests/CborCodingOptionsTests.swift
@@ -461,4 +461,58 @@ final class CborCodingOptionsTests: XCTestCase {
     XCTAssertEqual(try encoder.encode(Double(1.5)).hexDescription, "f93e00")
     XCTAssertThrowsError(try encoder.encode(Double.nan))
   }
+
+  func testFloatingPoint64OnlyAlwaysEncodesAsDouble() throws {
+    let encoder = CborEncoder(options: .floatingPoint64Only)
+    XCTAssertEqual(try encoder.encode(Float16(1.5)).hexDescription, "fb3ff8000000000000")
+    XCTAssertEqual(try encoder.encode(Float(1.5)).hexDescription, "fb3ff8000000000000")
+    XCTAssertEqual(try encoder.encode(Double(1.5)).hexDescription, "fb3ff8000000000000")
+  }
+
+  func testFloatingPoint64OnlyRejectsNarrowerInput() throws {
+    let decoder = CborDecoder(options: .floatingPoint64Only)
+    XCTAssertThrowsError(try decoder.decode(Float.self, from: Data(hex: "f93e00")))
+    XCTAssertThrowsError(try decoder.decode(Float.self, from: Data(hex: "fa3fc00000")))
+    XCTAssertEqual(try decoder.decode(Double.self, from: Data(hex: "fb3ff8000000000000")), 1.5)
+  }
+
+  func testFloatingPointEncodingOptionsConflict() {
+    let encodingOptions: CborEncoder.Options = [
+      .shortestFloatingPointEncoding, .floatingPoint64Only,
+    ]
+    XCTAssertThrowsError(try CborEncoder(options: encodingOptions).encode(1.5))
+
+    let decodingOptions: CborDecoder.Options = [
+      .shortestFloatingPointEncoding, .floatingPoint64Only,
+    ]
+    XCTAssertThrowsError(
+      try CborDecoder(options: decodingOptions).decode(
+        Double.self, from: Data(hex: "fb3ff8000000000000")))
+  }
+
+  func testFloatingPoint64OnlyRoundtripsBitIdentically() throws {
+    let encoder = CborEncoder(options: .floatingPoint64Only)
+    let decoder = CborDecoder(options: .floatingPoint64Only)
+    for value in [1.5, -0.0, Double.leastNonzeroMagnitude, Double.greatestFiniteMagnitude] {
+      let data = try encoder.encode(value)
+      XCTAssertEqual(data.first, 0xFB)
+      XCTAssertEqual(data.count, 9)
+      XCTAssertEqual(try decoder.decode(Double.self, from: data), value)
+    }
+  }
+
+  func testFloatingPoint64OnlyEncodesNonFiniteAsFloat64() throws {
+    let encoder = CborEncoder(options: .floatingPoint64Only)
+    XCTAssertEqual(try encoder.encode(Double.infinity).hexDescription, "fb7ff0000000000000")
+    XCTAssertEqual(try encoder.encode(-Double.infinity).hexDescription, "fbfff0000000000000")
+    XCTAssertEqual(try encoder.encode(Float16.infinity).hexDescription, "fb7ff0000000000000")
+  }
+
+  func testFloatingPoint64OnlyCombinesWithFiniteFloatingPointValuesOnly() throws {
+    let encoder = CborEncoder(
+      options: [.floatingPoint64Only, .finiteFloatingPointValuesOnly])
+    XCTAssertEqual(try encoder.encode(Double(1.5)).hexDescription, "fb3ff8000000000000")
+    XCTAssertThrowsError(try encoder.encode(Double.nan))
+    XCTAssertThrowsError(try encoder.encode(Double.infinity))
+  }
 }


### PR DESCRIPTION
This PR adds an option that pins CBOR floating-point encoding and decoding to the 64-bit (Double) representation.