### PR TITLE
feat: add CBOR tag allowlist decoder/encoder option

### DIFF
--- a/Sources/SwiftCbor/CborDecoder.swift
+++ b/Sources/SwiftCbor/CborDecoder.swift
@@ -10,9 +10,13 @@ extension Array: _CborArrayDecodableMarker where Element: Decodable {}
 
 open class CborDecoder {
   public var options: Options
+  public var allowedTags: Set<UInt64>?
 
-  public init(options: Options = []) {
+  public static let dagCborAllowedTags: Set<UInt64> = [42]
+
+  public init(options: Options = [], allowedTags: Set<UInt64>? = nil) {
     self.options = options
+    self.allowedTags = allowedTags
   }
 
   open func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
@@ -24,7 +28,7 @@ open class CborDecoder {
             "shortestFloatingPointEncoding and floatingPoint64Only cannot be combined."
         ))
     }
-    let scanner = CborScanner(data: data, options: options)
+    let scanner = CborScanner(data: data, options: options, allowedTags: allowedTags)
     let value = try scanner.scan()
     let decoder: _CborDecoder = .init(from: value)
     do {

--- a/Sources/SwiftCbor/CborEncoder.swift
+++ b/Sources/SwiftCbor/CborEncoder.swift
@@ -6,9 +6,13 @@ extension Dictionary: _CborDictionaryEncodableMarker where Key: Encodable, Value
 
 open class CborEncoder {
   public var options: Options
+  public var allowedTags: Set<UInt64>?
 
-  public init(options: Options = []) {
+  public static let dagCborAllowedTags: Set<UInt64> = [42]
+
+  public init(options: Options = [], allowedTags: Set<UInt64>? = nil) {
     self.options = options
+    self.allowedTags = allowedTags
   }
 
   open func encode(_ value: some Encodable) throws -> Data {
@@ -30,7 +34,7 @@ open class CborEncoder {
   }
 
   func encodeAsCborValue<T: Encodable>(_ value: T) throws -> CborEncodedValue {
-    let encoder = _CborEncoder(codingPath: [], options: options)
+    let encoder = _CborEncoder(codingPath: [], options: options, allowedTags: allowedTags)
     guard let result = try encoder.wrapEncodable(value, for: CodingKey?.none) else {
       throw EncodingError.invalidValue(
         value,
@@ -45,10 +49,14 @@ private class _CborEncoder: Encoder {
   public var codingPath: [CodingKey] = []
   public var userInfo: [CodingUserInfoKey: Any] = [:]
   let options: CborEncoder.Options
+  let allowedTags: Set<UInt64>?
 
-  init(codingPath: [CodingKey], options: CborEncoder.Options) {
+  init(
+    codingPath: [CodingKey], options: CborEncoder.Options, allowedTags: Set<UInt64>? = nil
+  ) {
     self.codingPath = codingPath
     self.options = options
+    self.allowedTags = allowedTags
   }
 
   var singleValue: CborEncodedValue?
@@ -496,17 +504,26 @@ extension _SpecialTreatmentEncoder {
   fileprivate func wrapCborEncodable(_ encodable: CborEncodable, for additionalKey: CodingKey?)
     throws -> CborEncodedValue?
   {
+    if let allowedTags = encoder.allowedTags, !allowedTags.contains(encodable.tag) {
+      throw EncodingError.invalidValue(
+        encodable,
+        .init(
+          codingPath: codingPath,
+          debugDescription: "CBOR tag \(encodable.tag) is not in the allowed tag set."
+        ))
+    }
     let tag = try encoder.wrapUInt(encodable.tag, majorType: 0b1100_0000, for: additionalKey)
-    let encoder = getEncoder(for: additionalKey)
-    try encodable.encode(to: encoder)
-    guard let value = encoder.value else { return nil }
+    let subEncoder = getEncoder(for: additionalKey)
+    try encodable.encode(to: subEncoder)
+    guard let value = subEncoder.value else { return nil }
     return .tagged(tag: tag, value: value)
   }
 
   fileprivate func getEncoder(for additionalKey: CodingKey?) -> _CborEncoder {
     if let additionalKey {
       let newCodidngPath: [CodingKey] = codingPath + [additionalKey]
-      return _CborEncoder(codingPath: newCodidngPath, options: encoder.options)
+      return _CborEncoder(
+        codingPath: newCodidngPath, options: encoder.options, allowedTags: encoder.allowedTags)
     }
     return encoder
   }

--- a/Sources/SwiftCbor/CborScanner.swift
+++ b/Sources/SwiftCbor/CborScanner.swift
@@ -4,11 +4,15 @@ class CborScanner {
   private let data: Data
   private var off: Int
   let options: CborDecoder.Options
+  let allowedTags: Set<UInt64>?
 
-  init(data: Data, options: CborDecoder.Options = []) {
+  init(
+    data: Data, options: CborDecoder.Options = [], allowedTags: Set<UInt64>? = nil
+  ) {
     self.data = data
     off = data.startIndex
     self.options = options
+    self.allowedTags = allowedTags
   }
 
   private func read(_ n: Int) -> Data {
@@ -150,7 +154,15 @@ class CborScanner {
   }
 
   private func scanTaggedValue(additional c: UInt8) throws -> CborValue {
-    return try .tagged(tag: .uint(_scanUInt(c: c)), value: scan())
+    let tag = try _scanUInt(c: c)
+    if let allowedTags, !allowedTags.contains(tag) {
+      throw DecodingError.dataCorrupted(
+        .init(
+          codingPath: [],
+          debugDescription: "CBOR tag \(tag) is not in the allowed tag set."
+        ))
+    }
+    return try .tagged(tag: .uint(tag), value: scan())
   }
 
   private func scanArray(additional c: UInt8) throws -> CborValue {

--- a/Tests/SwiftCborTests/CborCodingOptionsTests.swift
+++ b/Tests/SwiftCborTests/CborCodingOptionsTests.swift
@@ -515,4 +515,76 @@ final class CborCodingOptionsTests: XCTestCase {
     XCTAssertThrowsError(try encoder.encode(Double.nan))
     XCTAssertThrowsError(try encoder.encode(Double.infinity))
   }
+
+  func testAllowedTagsRestrictsTagsSymmetrically() throws {
+    let valid = TestTaggedValue(tag: 42, payload: .bytes(Data([0, 1, 2])))
+    let encoder = CborEncoder(allowedTags: [42])
+    let data = try encoder.encode(valid)
+    XCTAssertEqual(data.hexDescription, "d82a43000102")
+
+    let decoder = CborDecoder(allowedTags: [42])
+    XCTAssertNoThrow(try decoder.decode(TestBytesLink.self, from: data))
+
+    XCTAssertThrowsError(try encoder.encode(TestTaggedValue(tag: 1, payload: .integer(0))))
+    XCTAssertThrowsError(try decoder.decode(TestBytesLink.self, from: Data(hex: "c100")))
+  }
+
+  func testAllowedTagsDefaultAllowsAnyTag() throws {
+    let data = try CborEncoder().encode(TestTaggedValue(tag: 99, payload: .integer(0)))
+    XCTAssertEqual(data.hexDescription, "d86300")
+    XCTAssertNoThrow(try CborDecoder().decode(TestBytesLink.self, from: Data(hex: "d82a43000102")))
+  }
+
+  func testAllowedTagsEmptySetRejectsAllTaggedValues() {
+    let encoder = CborEncoder(allowedTags: [])
+    XCTAssertThrowsError(try encoder.encode(TestTaggedValue(tag: 42, payload: .integer(0))))
+
+    let decoder = CborDecoder(allowedTags: [])
+    XCTAssertThrowsError(try decoder.decode(TestBytesLink.self, from: Data(hex: "d82a43000102")))
+  }
+
+  func testDagCborAllowedTagsPresetIsTag42() {
+    XCTAssertEqual(CborDecoder.dagCborAllowedTags, [42])
+    XCTAssertEqual(CborEncoder.dagCborAllowedTags, [42])
+  }
+
+  func testCborCodableTypeValidatesItsOwnPayload() {
+    let decoder = CborDecoder(allowedTags: [42])
+    XCTAssertThrowsError(try decoder.decode(TestBytesLink.self, from: Data(hex: "d82a01")))
+    XCTAssertThrowsError(try decoder.decode(TestBytesLink.self, from: Data(hex: "d82a4101")))
+  }
+}
+
+private struct TestTaggedValue: CborEncodable {
+  enum Payload {
+    case integer(Int)
+    case bytes(Data)
+  }
+  let tag: UInt64
+  let payload: Payload
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch payload {
+    case .integer(let value): try container.encode(value)
+    case .bytes(let value): try container.encode(value)
+    }
+  }
+}
+
+private struct TestBytesLink: CborDecodable {
+  let bytes: Data
+  var tag: UInt64 { 42 }
+
+  init(from decoder: Decoder) throws {
+    let raw = try decoder.singleValueContainer().decode(Data.self)
+    guard raw.first == 0 else {
+      throw DecodingError.dataCorrupted(
+        .init(
+          codingPath: decoder.codingPath,
+          debugDescription: "DAG-CBOR link payload must start with 0x00."
+        ))
+    }
+    bytes = raw
+  }
 }


### PR DESCRIPTION
This PR adds a general mechanism to restrict which CBOR tags are accepted during encode and decode:

- adds `allowedTags: Set<UInt64>?` initializer parameter to `CborEncoder` and `CborDecoder`
- treats `nil` as "any tag allowed" (default), `[42]` as "only that tag", `[]` as "no tagged values"
- rejects out-of-set tags at both scanner and encoder boundaries with a clear error message
- exposes `dagCborAllowedTags: Set<UInt64> = [42]` on both types as a preset for the DAG-CBOR CID tag