### PR TITLE
feat: add valid UTF-8 CBOR option

### DIFF
--- a/Sources/SwiftCbor/CborDecoderOptions.swift
+++ b/Sources/SwiftCbor/CborDecoderOptions.swift
@@ -14,6 +14,7 @@ extension CborDecoder {
     public static let basicSimpleValuesOnly = Options(rawValue: 1 << 5)
     public static let finiteFloatingPointValuesOnly = Options(rawValue: 1 << 6)
     public static let floatingPoint64Only = Options(rawValue: 1 << 7)
+    public static let validUTF8Only = Options(rawValue: 1 << 8)
 
     var hasConflictingFloatingPointOptions: Bool {
       contains(.shortestFloatingPointEncoding) && contains(.floatingPoint64Only)

--- a/Sources/SwiftCbor/CborScanner.swift
+++ b/Sources/SwiftCbor/CborScanner.swift
@@ -58,7 +58,15 @@ class CborScanner {
   }
 
   private func scanString(additional: UInt8) throws -> CborValue {
-    try .literal(.str(scanSequence(additional: additional)))
+    let bytes = try scanSequence(additional: additional)
+    if options.contains(.validUTF8Only), String(data: bytes, encoding: .utf8) == nil {
+      throw DecodingError.dataCorrupted(
+        .init(
+          codingPath: [],
+          debugDescription: "CBOR text string is not valid UTF-8."
+        ))
+    }
+    return .literal(.str(bytes))
   }
 
   private func scanSequence(additional c: UInt8) throws -> Data {

--- a/Tests/SwiftCborTests/CborCodingOptionsTests.swift
+++ b/Tests/SwiftCborTests/CborCodingOptionsTests.swift
@@ -553,6 +553,16 @@ final class CborCodingOptionsTests: XCTestCase {
     XCTAssertThrowsError(try decoder.decode(TestBytesLink.self, from: Data(hex: "d82a01")))
     XCTAssertThrowsError(try decoder.decode(TestBytesLink.self, from: Data(hex: "d82a4101")))
   }
+
+  func testValidUTF8OnlyRejectsIllFormedText() {
+    let decoder = CborDecoder(options: .validUTF8Only)
+    XCTAssertThrowsError(try decoder.decode(String.self, from: Data(hex: "61ff")))
+  }
+
+  func testValidUTF8OnlyAcceptsValidText() throws {
+    let decoder = CborDecoder(options: .validUTF8Only)
+    XCTAssertEqual(try decoder.decode(String.self, from: Data(hex: "63e38182")), "あ")
+  }
 }
 
 private struct TestTaggedValue: CborEncodable {


### PR DESCRIPTION
This PR adds an option that rejects CBOR text strings whose bytes are not valid UTF-8.