### PR TITLE
feat: add single top-level CBOR item option

### DIFF
--- a/Sources/SwiftCbor/CborDecoder.swift
+++ b/Sources/SwiftCbor/CborDecoder.swift
@@ -30,6 +30,13 @@ open class CborDecoder {
     }
     let scanner = CborScanner(data: data, options: options, allowedTags: allowedTags)
     let value = try scanner.scan()
+    if options.contains(.singleTopLevelItem), !scanner.isAtEnd {
+      throw DecodingError.dataCorrupted(
+        .init(
+          codingPath: [],
+          debugDescription: "CBOR input contains bytes after the top-level item."
+        ))
+    }
     let decoder: _CborDecoder = .init(from: value)
     do {
       return try decoder.unwrap(as: T.self)

--- a/Sources/SwiftCbor/CborDecoderOptions.swift
+++ b/Sources/SwiftCbor/CborDecoderOptions.swift
@@ -15,6 +15,7 @@ extension CborDecoder {
     public static let finiteFloatingPointValuesOnly = Options(rawValue: 1 << 6)
     public static let floatingPoint64Only = Options(rawValue: 1 << 7)
     public static let validUTF8Only = Options(rawValue: 1 << 8)
+    public static let singleTopLevelItem = Options(rawValue: 1 << 9)
 
     var hasConflictingFloatingPointOptions: Bool {
       contains(.shortestFloatingPointEncoding) && contains(.floatingPoint64Only)

--- a/Sources/SwiftCbor/CborScanner.swift
+++ b/Sources/SwiftCbor/CborScanner.swift
@@ -5,6 +5,7 @@ class CborScanner {
   private var off: Int
   let options: CborDecoder.Options
   let allowedTags: Set<UInt64>?
+  var isAtEnd: Bool { off == data.endIndex }
 
   init(
     data: Data, options: CborDecoder.Options = [], allowedTags: Set<UInt64>? = nil

--- a/Tests/SwiftCborTests/CborCodingOptionsTests.swift
+++ b/Tests/SwiftCborTests/CborCodingOptionsTests.swift
@@ -563,6 +563,44 @@ final class CborCodingOptionsTests: XCTestCase {
     let decoder = CborDecoder(options: .validUTF8Only)
     XCTAssertEqual(try decoder.decode(String.self, from: Data(hex: "63e38182")), "あ")
   }
+
+  func testSingleTopLevelItemRejectsTrailingData() {
+    let decoder = CborDecoder(options: .singleTopLevelItem)
+    XCTAssertThrowsError(try decoder.decode(Int.self, from: Data(hex: "0102")))
+    XCTAssertThrowsError(try decoder.decode([Int].self, from: Data(hex: "810102")))
+  }
+
+  func testSingleTopLevelItemAcceptsFullyConsumedInput() throws {
+    let decoder = CborDecoder(options: .singleTopLevelItem)
+    XCTAssertEqual(try decoder.decode([Int].self, from: Data(hex: "8101")), [1])
+  }
+
+  func testSingleTopLevelItemAcceptsFullyConsumedDataSlice() throws {
+    let decoder = CborDecoder(options: .singleTopLevelItem)
+    let slice = Data(hex: "008101").dropFirst()
+    XCTAssertEqual(try decoder.decode([Int].self, from: slice), [1])
+  }
+
+  func testSingleTopLevelItemRejectsTrailingDataInDataSlice() {
+    let decoder = CborDecoder(options: .singleTopLevelItem)
+    let slice = Data(hex: "0081010203").dropFirst()
+    XCTAssertThrowsError(try decoder.decode([Int].self, from: slice))
+  }
+
+  func testSingleTopLevelItemRejectsTrailingDataAfterMap() {
+    let decoder = CborDecoder(options: .singleTopLevelItem)
+    XCTAssertThrowsError(try decoder.decode([String: Int].self, from: Data(hex: "a1616101ff")))
+  }
+
+  func testSingleTopLevelItemRejectsTrailingDataAfterTaggedValue() {
+    let decoder = CborDecoder(options: .singleTopLevelItem, allowedTags: [42])
+    XCTAssertThrowsError(try decoder.decode(TestBytesLink.self, from: Data(hex: "d82a4100ff")))
+  }
+
+  func testSingleTopLevelItemRejectsTrailingDataAfterIndefiniteArray() {
+    let decoder = CborDecoder(options: .singleTopLevelItem)
+    XCTAssertThrowsError(try decoder.decode([Int].self, from: Data(hex: "9f01ff00")))
+  }
 }
 
 private struct TestTaggedValue: CborEncodable {


### PR DESCRIPTION
This PR adds an option that rejects CBOR payloads containing extra bytes after the top-level item.