### PR TITLE
feat: add floating-point disallowed CBOR option

### DIFF
--- a/Sources/SwiftCbor/CborDecoderOptions.swift
+++ b/Sources/SwiftCbor/CborDecoderOptions.swift
@@ -16,6 +16,7 @@ extension CborDecoder {
     public static let floatingPoint64Only = Options(rawValue: 1 << 7)
     public static let validUTF8Only = Options(rawValue: 1 << 8)
     public static let singleTopLevelItem = Options(rawValue: 1 << 9)
+    public static let floatingPointValuesDisallowed = Options(rawValue: 1 << 10)
 
     var hasConflictingFloatingPointOptions: Bool {
       contains(.shortestFloatingPointEncoding) && contains(.floatingPoint64Only)

--- a/Sources/SwiftCbor/CborScanner.swift
+++ b/Sources/SwiftCbor/CborScanner.swift
@@ -84,6 +84,10 @@ class CborScanner {
   }
 
   private func scanFloat(additional c: UInt8) throws -> CborValue {
+    if options.contains(.floatingPointValuesDisallowed), (0x19...0x1B).contains(c) {
+      throw DecodingError.dataCorrupted(
+        .init(codingPath: [], debugDescription: "Floating-point values are not permitted."))
+    }
     switch c {
     case 0x00...0x13:
       if options.contains(.basicSimpleValuesOnly) { throw unsupportedSimpleValue(c) }

--- a/Tests/SwiftCborTests/CborCodingOptionsTests.swift
+++ b/Tests/SwiftCborTests/CborCodingOptionsTests.swift
@@ -516,6 +516,38 @@ final class CborCodingOptionsTests: XCTestCase {
     XCTAssertThrowsError(try encoder.encode(Double.infinity))
   }
 
+  func testFloatingPointValuesDisallowedRejectsFloat16() {
+    let decoder = CborDecoder(options: .floatingPointValuesDisallowed)
+    XCTAssertThrowsError(try decoder.decode(Double.self, from: Data(hex: "f93e00")))
+  }
+
+  func testFloatingPointValuesDisallowedRejectsFloat32() {
+    let decoder = CborDecoder(options: .floatingPointValuesDisallowed)
+    XCTAssertThrowsError(try decoder.decode(Double.self, from: Data(hex: "fa3fc00000")))
+  }
+
+  func testFloatingPointValuesDisallowedRejectsFloat64() {
+    let decoder = CborDecoder(options: .floatingPointValuesDisallowed)
+    XCTAssertThrowsError(try decoder.decode(Double.self, from: Data(hex: "fb3ff8000000000000")))
+  }
+
+  func testFloatingPointValuesDisallowedAcceptsIntegers() throws {
+    let decoder = CborDecoder(options: .floatingPointValuesDisallowed)
+    XCTAssertEqual(try decoder.decode(Int.self, from: Data(hex: "01")), 1)
+  }
+
+  func testFloatingPointValuesDisallowedAcceptsBoolAndNull() throws {
+    let decoder = CborDecoder(options: .floatingPointValuesDisallowed)
+    XCTAssertEqual(try decoder.decode(Bool.self, from: Data(hex: "f4")), false)
+    XCTAssertEqual(try decoder.decode(Bool.self, from: Data(hex: "f5")), true)
+    XCTAssertNil(try decoder.decode(Int?.self, from: Data(hex: "f6")))
+  }
+
+  func testFloatingPointValuesDisallowedRejectsFloatNestedInArray() {
+    let decoder = CborDecoder(options: .floatingPointValuesDisallowed)
+    XCTAssertThrowsError(try decoder.decode([Double].self, from: Data(hex: "81f93e00")))
+  }
+
   func testAllowedTagsRestrictsTagsSymmetrically() throws {
     let valid = TestTaggedValue(tag: 42, payload: .bytes(Data([0, 1, 2])))
     let encoder = CborEncoder(allowedTags: [42])


### PR DESCRIPTION
This PR adds an option that rejects every floating-point CBOR value during decode.