### PR TITLE
chore: remove DAG-CBOR tag preset

### DIFF
--- a/Sources/SwiftCbor/CborDecoder.swift
+++ b/Sources/SwiftCbor/CborDecoder.swift
@@ -12,8 +12,6 @@ open class CborDecoder {
   public var options: Options
   public var allowedTags: Set<UInt64>?
 
-  public static let dagCborAllowedTags: Set<UInt64> = [42]
-
   public init(options: Options = [], allowedTags: Set<UInt64>? = nil) {
     self.options = options
     self.allowedTags = allowedTags

--- a/Sources/SwiftCbor/CborEncoder.swift
+++ b/Sources/SwiftCbor/CborEncoder.swift
@@ -8,8 +8,6 @@ open class CborEncoder {
   public var options: Options
   public var allowedTags: Set<UInt64>?
 
-  public static let dagCborAllowedTags: Set<UInt64> = [42]
-
   public init(options: Options = [], allowedTags: Set<UInt64>? = nil) {
     self.options = options
     self.allowedTags = allowedTags

--- a/Tests/SwiftCborTests/CborCodingOptionsTests.swift
+++ b/Tests/SwiftCborTests/CborCodingOptionsTests.swift
@@ -575,11 +575,6 @@ final class CborCodingOptionsTests: XCTestCase {
     XCTAssertThrowsError(try decoder.decode(TestBytesLink.self, from: Data(hex: "d82a43000102")))
   }
 
-  func testDagCborAllowedTagsPresetIsTag42() {
-    XCTAssertEqual(CborDecoder.dagCborAllowedTags, [42])
-    XCTAssertEqual(CborEncoder.dagCborAllowedTags, [42])
-  }
-
   func testCborCodableTypeValidatesItsOwnPayload() {
     let decoder = CborDecoder(allowedTags: [42])
     XCTAssertThrowsError(try decoder.decode(TestBytesLink.self, from: Data(hex: "d82a01")))


### PR DESCRIPTION
This PR removes the DAG-CBOR-specific preset from swift-cbor so the package stays free of DAG-CBOR knowledge.